### PR TITLE
fix: setup.cfg, supports adding submodules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,3 +22,6 @@ pybind11_add_module(_core MODULE src/main.cpp)
 target_compile_definitions(_core PRIVATE VERSION_INFO=${PROJECT_VERSION})
 
 install(TARGETS _core DESTINATION .)
+
+# file(GLOB_RECURSE PY_FILE_LIST RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/src" src/*.py)
+# install(FILES ${PY_FILE_LIST} DESTINATION .)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,11 @@
+[metadata]
+name = scikit_build_example
+version = 0.0.1
+author = Henry Schreiner
+license = MIT
+description = a minimal example package (with pybind11)
+long_description = file: README.md
+long_description_content_type = text/markdown
+
+[options]
+python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ import sys
 
 try:
     from skbuild import setup
+    from setuptools import find_packages
 except ImportError:
     print(
         "Please update pip, you need pip 10 or greater,\n"
@@ -18,13 +19,8 @@ from setuptools import find_packages
 
 
 setup(
-    name="scikit_build_example",
-    version="0.0.1",
-    description="a minimal example package (with pybind11)",
-    author="Henry Schreiner",
-    license="MIT",
     packages=find_packages(where = 'src'),
-    package_dir={"": "src"},
-    cmake_install_dir="src/scikit_build_example",
+    package_dir={'': 'src'},
+    cmake_install_dir='src/scikit_build_example',
     include_package_data = True,
 )


### PR DESCRIPTION
Fixes an issue trying to add submodules discovered by @davidt0x. Packages should always use `find:`, with includes/excludes if needed, rather than listing the packages. There might be a bug in scikit-build that causes the manual way to fail.

Moving to a proper setup.cfg setup as well.